### PR TITLE
Update core/components/advsearch/model/advsearch/advsearchform.class.php

### DIFF
--- a/core/components/advsearch/model/advsearch/advsearchform.class.php
+++ b/core/components/advsearch/model/advsearch/advsearchform.class.php
@@ -168,7 +168,7 @@ class AdvSearchForm extends AdvSearchUtil {
             foreach ($jsHeaderArray as $key => $value)
                 $jsonPair[] = '"' . $key . '":"' . $value . '"';
             $json = '{' . implode(',', $jsonPair) . '}';
-            $jsline = "advsea[advsea.length]='{$json}';";
+            $jsline = "var advsea=advsea || [];advsea[advsea.length]='{$json}';";
             $jsHeader = <<<EOD
 <!-- start AdvSearch header -->
 <script type="text/javascript">
@@ -180,7 +180,7 @@ class AdvSearchForm extends AdvSearchUtil {
 EOD;
             if ($this->config['addJs'] == 1)
                 $this->modx->regClientStartupScript($jsHeader);
-            else
+            else if ($this->config['addJs'] == 2)
                 $this->modx->regClientScript($jsHeader);
         }
 


### PR DESCRIPTION
Added conditional so that if user chose 0 for addJs, inline js would not be output. This is because advsea var was not initialized as the prior js files were not loaded.

I've also added the js to check advsea for undefined as an extra measure, since this would be prove useful if your intentions were to allow access to these vars even if addJs was 0. In that case, you can remove my first change, while keeping the js.
