### PR TITLE
Update advsearchutil.class.php

### DIFF
--- a/core/components/advsearch/model/advsearch/advsearchutil.class.php
+++ b/core/components/advsearch/model/advsearch/advsearchutil.class.php
@@ -444,7 +444,7 @@ abstract class AdvSearchUtil {
      * @return string Elapsed time since start
      */
     public function getElapsedTime($start = 0) {
-        $tend = $this->modx->getMicroTime();
+        $tend = microtime(true);
         if ($start) {
             $eTime = ($tend - $start);
         } else {


### PR DESCRIPTION
Replace getMicroTime method with standart PHP microtime. getMicroTime was deleted in modx 2.3.
