### PR TITLE
Improve highlighting when search match is surrounded with spaces

### DIFF
--- a/core/components/advsearch/model/advsearch/advsearch.class.php
+++ b/core/components/advsearch/model/advsearch/advsearch.class.php
@@ -719,7 +719,7 @@ class AdvSearch {
             if (empty($rank)) {
                 $rank = ($key + 1);
             }
-            $string = preg_replace('/(\s*)(' . $pattern . ')(\s*)/i', '<' . $tag . ' class="' . $class . ' ' . $class . '-' . $rank . '">$0</' . $tag . '>', $string);
+            $string = preg_replace('/(\s*)(' . $pattern . ')(\s*)/i', '$1<' . $tag . ' class="' . $class . ' ' . $class . '-' . $rank . '">$2</' . $tag . '>$3', $string);
         }
 
         return $string;


### PR DESCRIPTION
Fix: AdvSearch::addHighlighting() preg_replace highlighted spaces around the search terms, if happened to be there. Now it only highlights the exact search term, whitespaces are not highlighted.