### PR TITLE
search input was broken if search contained "

### DIFF
--- a/core/components/advsearch/model/advsearch/advsearchform.class.php
+++ b/core/components/advsearch/model/advsearch/advsearchform.class.php
@@ -121,7 +121,7 @@ class AdvSearchForm extends AdvSearch {
             'method' => $this->config['method'],
             'landing' => $this->config['landing'],
             'asId' => $this->config['asId'],
-            'searchValue' => $this->searchString,
+            'searchValue' => htmlentities( $this->searchString ),
             'searchIndex' => $this->config['searchIndex'],
             'helpLink' => $helpLink,
             'liveSearch' => $this->config['liveSearch'],


### PR DESCRIPTION
Fix: special characters in search string was breaking the HTML code for the search input form field